### PR TITLE
Refactor: change method to use active record rather than itterating

### DIFF
--- a/app/models/lot.rb
+++ b/app/models/lot.rb
@@ -12,7 +12,7 @@ class Lot < ApplicationRecord
   end
 
   def self.sort_by_bag_count
-    all.sort_by { |lot| lot.bag_count }.reverse
+    left_joins(:bags).group(:id).order('COUNT(bags.id) DESC')
   end
 
   def self.sort_by_creation_date


### PR DESCRIPTION
### What does this PR do?
  - Update sort_by_bag_count method to use active record instead of ruby
  
### Does this PR break anything?
 - [ ] Yes
 - [X] No
 - If yes, explain: 
